### PR TITLE
Chunk try

### DIFF
--- a/src/components/objects/Chunk/Chunk.js
+++ b/src/components/objects/Chunk/Chunk.js
@@ -38,9 +38,9 @@ class Chunk extends Group {
   }
 
   disposeOf() {
-
-    this.terrain.disposeOf()
     this.remove(this.terrain)
+
+    return this.terrain.disposeOf()
   }
 
 }

--- a/src/components/objects/Chunk/Chunk.js
+++ b/src/components/objects/Chunk/Chunk.js
@@ -3,8 +3,7 @@ import { TerrainPlane } from '../TerrainPlane';
 
 
 class Chunk extends Group {
-
-  constructor(parent, xOffset, yOffset, zOffset) {
+  constructor(parent, xOffset, yOffset, zOffset, plane_geometry) {
       // console.log("CONSTRUCTOR CHUNK x: " + xOffset + " t: " + yOffset + " z: " + zOffset)
       // Call parent Group() constructor
       super();
@@ -17,12 +16,11 @@ class Chunk extends Group {
       };
 
       // feed in the parent (chunk manager) as it has the proper terrain variables
-      this.terrain = new TerrainPlane(parent, xOffset, yOffset, zOffset)
+      this.terrain = new TerrainPlane(parent, xOffset, yOffset, zOffset, plane_geometry)
       this.add(this.terrain);
 
       this.position.x = xOffset;
       this.position.z = zOffset;
-
   }
 
   updateNoise() {

--- a/src/components/objects/ChunkManager/ChunkManager.js
+++ b/src/components/objects/ChunkManager/ChunkManager.js
@@ -75,12 +75,7 @@ class ChunkManager extends Group {
           const new_chunk = new Chunk(this, coordinates[i][0], coordinates[i][1], coordinates[i][2], new_plane_geo);
           this.add(new_chunk);
           this.state.chunks.push(new_chunk);
-          console.log('print new chunk: ')
-          console.log(new_chunk);
         }
-
-        console.log(`new chunk init ${this.state.chunks}`)
-        console.log(this.state.chunks)
 
         // Add self to parent's update list
         parent.addToUpdateList(this);
@@ -132,18 +127,8 @@ class ChunkManager extends Group {
     update(timeStamp, x, y, z) {
       // console.log("Update in chunk manager. x: " + x + " y: " + y + " z: " + z)
       // make/delete chunks as needed
-      let plane_geos;
-      if ((z > this.state.chunkWidth/2) || (z < -this.state.chunkWidth/2) ||
-          (x > this.state.chunkWidth/2) || (x < -this.state.chunkWidth/2)) {
-         plane_geos = [
-          new PlaneGeometry(this.state.chunkWidth, this.state.chunkWidth,
-                                      this.state.chunkVertWidth - 1, this.state.chunkVertWidth - 1),
-          new PlaneGeometry(this.state.chunkWidth, this.state.chunkWidth,
-                                      this.state.chunkVertWidth - 1, this.state.chunkVertWidth - 1),
-          new PlaneGeometry(this.state.chunkWidth, this.state.chunkWidth,
-                                      this.state.chunkVertWidth - 1, this.state.chunkVertWidth - 1)
-        ];
-      }
+      // Initialized asa 0 but are actually supposed to be PlaneGeometry objects
+      let plane_geos = [0, 0, 0];
 
       if(z > this.state.chunkWidth/2) {
         this.state.currentZOffset += this.state.chunkWidth;
@@ -151,9 +136,9 @@ class ChunkManager extends Group {
         this.remove(this.state.chunks[6])
         this.remove(this.state.chunks[7])
         this.remove(this.state.chunks[8])
-        this.state.chunks[6].disposeOf()
-        this.state.chunks[7].disposeOf()
-        this.state.chunks[8].disposeOf()
+        plane_geos[0] = this.state.chunks[6].disposeOf();
+        plane_geos[1] = this.state.chunks[7].disposeOf()
+        plane_geos[2] = this.state.chunks[8].disposeOf()
 
         // move everything a row back. Chunks[] help us keep track of this
         this.state.chunks[6] = this.state.chunks[3]
@@ -172,10 +157,6 @@ class ChunkManager extends Group {
         this.state.chunks[2] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset,plane_geos
         [2]);
 
-        this.add(this.state.chunks[0])
-        this.add(this.state.chunks[1])
-        this.add(this.state.chunks[2])
-
         // move all pieces to correct position relative to center block
         // top row
         this.state.chunks[0].setChunkPosition(this.state.chunkWidth, 0, this.state.chunkWidth)
@@ -192,6 +173,9 @@ class ChunkManager extends Group {
 
         this.state.parent.state.z -= this.state.chunkWidth;
 
+        this.add(this.state.chunks[0])
+        this.add(this.state.chunks[1])
+        this.add(this.state.chunks[2])
       }
       else if(z < -this.state.chunkWidth/2) {
         this.state.currentZOffset -= this.state.chunkWidth;
@@ -199,9 +183,9 @@ class ChunkManager extends Group {
         this.remove(this.state.chunks[0])
         this.remove(this.state.chunks[1])
         this.remove(this.state.chunks[2])
-        this.state.chunks[0].disposeOf()
-        this.state.chunks[1].disposeOf()
-        this.state.chunks[2].disposeOf()
+        plane_geos[0] = this.state.chunks[0].disposeOf()
+        plane_geos[1] = this.state.chunks[1].disposeOf()
+        plane_geos[2] = this.state.chunks[2].disposeOf()
 
         // move everything a row forward. Chunks[] help us keep track of this
         this.state.chunks[0] = this.state.chunks[3]
@@ -220,9 +204,7 @@ class ChunkManager extends Group {
         this.state.chunks[8] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset,plane_geos
         [2]);
 
-        this.add(this.state.chunks[6])
-        this.add(this.state.chunks[7])
-        this.add(this.state.chunks[8])
+
 
         // move all pieces to correct position relative to center block
         // top row
@@ -239,6 +221,10 @@ class ChunkManager extends Group {
         this.state.chunks[8].setChunkPosition(-this.state.chunkWidth, 0, -this.state.chunkWidth)
 
         this.state.parent.state.z += this.state.chunkWidth;
+
+        this.add(this.state.chunks[6])
+        this.add(this.state.chunks[7])
+        this.add(this.state.chunks[8])
       }
 
 
@@ -249,9 +235,9 @@ class ChunkManager extends Group {
         this.remove(this.state.chunks[2])
         this.remove(this.state.chunks[5])
         this.remove(this.state.chunks[8])
-        this.state.chunks[2].disposeOf()
-        this.state.chunks[5].disposeOf()
-        this.state.chunks[8].disposeOf()
+        plane_geos[0] = this.state.chunks[2].disposeOf()
+        plane_geos[1] = this.state.chunks[5].disposeOf()
+        plane_geos[2] = this.state.chunks[8].disposeOf()
 
         // move everything a column right. Chunks[] help us keep track of this
         this.state.chunks[2] = this.state.chunks[1]
@@ -270,9 +256,7 @@ class ChunkManager extends Group {
         this.state.chunks[6] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset,plane_geos
         [2]);
 
-        this.add(this.state.chunks[0])
-        this.add(this.state.chunks[3])
-        this.add(this.state.chunks[6])
+
 
         // move all pieces to correct position relative to center block
         // top row
@@ -289,6 +273,10 @@ class ChunkManager extends Group {
         this.state.chunks[8].setChunkPosition(-this.state.chunkWidth, 0, -this.state.chunkWidth)
 
         this.state.parent.state.x -= this.state.chunkWidth;
+
+        this.add(this.state.chunks[0])
+        this.add(this.state.chunks[3])
+        this.add(this.state.chunks[6])
       }
 
       else if(x < -this.state.chunkWidth/2) {
@@ -297,9 +285,9 @@ class ChunkManager extends Group {
         this.remove(this.state.chunks[0])
         this.remove(this.state.chunks[3])
         this.remove(this.state.chunks[6])
-        this.state.chunks[0].disposeOf()
-        this.state.chunks[3].disposeOf()
-        this.state.chunks[6].disposeOf()
+        plane_geos[0] = this.state.chunks[0].disposeOf()
+        plane_geos[1] = this.state.chunks[3].disposeOf()
+        plane_geos[2] = this.state.chunks[6].disposeOf()
 
 
         // move everything a column left. Chunks[] help us keep track of this
@@ -319,9 +307,7 @@ class ChunkManager extends Group {
         this.state.chunks[8] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset, plane_geos
         [2]);
 
-        this.add(this.state.chunks[2])
-        this.add(this.state.chunks[5])
-        this.add(this.state.chunks[8])
+
 
         // move all pieces to correct position relative to center block
         // top row
@@ -338,6 +324,10 @@ class ChunkManager extends Group {
         this.state.chunks[8].setChunkPosition(-this.state.chunkWidth, 0, -this.state.chunkWidth)
 
         this.state.parent.state.x += this.state.chunkWidth;
+
+        this.add(this.state.chunks[2])
+        this.add(this.state.chunks[5])
+        this.add(this.state.chunks[8])
       }
 
       this.position.x = -x;
@@ -345,6 +335,8 @@ class ChunkManager extends Group {
       this.position.z = -z;
 
     }
+
+
 }
 
 export default ChunkManager;

--- a/src/components/objects/ChunkManager/ChunkManager.js
+++ b/src/components/objects/ChunkManager/ChunkManager.js
@@ -182,15 +182,6 @@ class ChunkManager extends Group {
         this.state.chunks[1].setChunkPosition(0, 0, this.state.chunkWidth)
         this.state.chunks[2].setChunkPosition(-this.state.chunkWidth, 0, this.state.chunkWidth)
 
-        remove1.disposeOf()
-        remove2.disposeOf()
-        remove3.disposeOf()
-        this.add(this.state.chunks[0])
-        this.add(this.state.chunks[1])
-        this.add(this.state.chunks[2])
-
-        return;
-
         this.add(this.state.chunks[0])
         this.add(this.state.chunks[1])
         this.add(this.state.chunks[2])

--- a/src/components/objects/ChunkManager/ChunkManager.js
+++ b/src/components/objects/ChunkManager/ChunkManager.js
@@ -1,6 +1,5 @@
-import { Group, Color } from 'three';
+import { Group, Color, PlaneGeometry } from 'three';
 import  SimplexNoise  from 'simplex-noise';
-
 import { Chunk } from '../Chunk';
 
 /*
@@ -55,46 +54,33 @@ class ChunkManager extends Group {
 
         this.state.simplex = new SimplexNoise(this.state.randSeed);
 
-        const chunk0 = new Chunk(this, this.state.chunkWidth, 0, this.state.chunkWidth);
-        this.add(chunk0);
-        this.state.chunks.push(chunk0);
 
-        const chunk1 = new Chunk(this, 0, 0, this.state.chunkWidth);
-        this.add(chunk1);
-        this.state.chunks.push(chunk1);
 
-        const chunk2 = new Chunk(this, -this.state.chunkWidth, 0, this.state.chunkWidth);
-        this.add(chunk2);
-        this.state.chunks.push(chunk2);
 
-        const chunk3 = new Chunk(this, this.state.chunkWidth, 0, 0);
-        this.add(chunk3);
-        this.state.chunks.push(chunk3);
+        const coordinates = [
+          [this.state.chunkWidth, 0, this.state.chunkWidth],
+          [0, 0, this.state.chunkWidth],
+          [-this.state.chunkWidth, 0, this.state.chunkWidth],
+          [this.state.chunkWidth, 0, 0],
+          [0, 0, 0],
+          [-this.state.chunkWidth, 0, 0],
+          [this.state.chunkWidth, 0, -this.state.chunkWidth],
+          [0, 0, -this.state.chunkWidth],
+          [-this.state.chunkWidth, 0, -this.state.chunkWidth]
+        ]
 
-        const chunk4 = new Chunk(this, 0, 0, 0);
-        this.add(chunk4);
-        this.state.chunks.push(chunk4);
+        for (let i = 0; i < coordinates.length; i++) {
+          let new_plane_geo = new PlaneGeometry(this.state.chunkWidth, this.state.chunkWidth,
+                                      this.state.chunkVertWidth - 1, this.state.chunkVertWidth - 1);
+          const new_chunk = new Chunk(this, coordinates[i][0], coordinates[i][1], coordinates[i][2], new_plane_geo);
+          this.add(new_chunk);
+          this.state.chunks.push(new_chunk);
+          console.log('print new chunk: ')
+          console.log(new_chunk);
+        }
 
-        const chunk5 = new Chunk(this, -this.state.chunkWidth, 0, 0);
-        this.add(chunk5);
-        this.state.chunks.push(chunk5);
-
-        const chunk6 = new Chunk(this, this.state.chunkWidth, 0, -this.state.chunkWidth);
-        this.add(chunk6);
-        this.state.chunks.push(chunk6);
-
-        const chunk7 = new Chunk(this, 0, 0, -this.state.chunkWidth);
-        this.add(chunk7);
-        this.state.chunks.push(chunk7);
-
-        const chunk8 = new Chunk(this, -this.state.chunkWidth, 0, -this.state.chunkWidth);
-        this.add(chunk8);
-        this.state.chunks.push(chunk8);
-
-/*
-        const chunk9 = new Chunk(this, 0, 0, -2*this.state.chunkWidth);
-        this.add(chunk9);
-        this.state.chunks.push(chunk9); */
+        console.log(`new chunk init ${this.state.chunks}`)
+        console.log(this.state.chunks)
 
         // Add self to parent's update list
         parent.addToUpdateList(this);
@@ -146,6 +132,18 @@ class ChunkManager extends Group {
     update(timeStamp, x, y, z) {
       // console.log("Update in chunk manager. x: " + x + " y: " + y + " z: " + z)
       // make/delete chunks as needed
+      let plane_geos;
+      if ((z > this.state.chunkWidth/2) || (z < -this.state.chunkWidth/2) ||
+          (x > this.state.chunkWidth/2) || (x < -this.state.chunkWidth/2)) {
+         plane_geos = [
+          new PlaneGeometry(this.state.chunkWidth, this.state.chunkWidth,
+                                      this.state.chunkVertWidth - 1, this.state.chunkVertWidth - 1),
+          new PlaneGeometry(this.state.chunkWidth, this.state.chunkWidth,
+                                      this.state.chunkVertWidth - 1, this.state.chunkVertWidth - 1),
+          new PlaneGeometry(this.state.chunkWidth, this.state.chunkWidth,
+                                      this.state.chunkVertWidth - 1, this.state.chunkVertWidth - 1)
+        ];
+      }
 
       if(z > this.state.chunkWidth/2) {
         this.state.currentZOffset += this.state.chunkWidth;
@@ -167,9 +165,12 @@ class ChunkManager extends Group {
         this.state.chunks[5] = this.state.chunks[2]
 
         // make new chunks with proper offset
-        this.state.chunks[0] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset);
-        this.state.chunks[1] = new Chunk(this, this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset);
-        this.state.chunks[2] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset);
+        this.state.chunks[0] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset, plane_geos
+        [0]);
+        this.state.chunks[1] = new Chunk(this, this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset,plane_geos
+        [1]);
+        this.state.chunks[2] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset,plane_geos
+        [2]);
 
         this.add(this.state.chunks[0])
         this.add(this.state.chunks[1])
@@ -212,9 +213,12 @@ class ChunkManager extends Group {
         this.state.chunks[5] = this.state.chunks[8]
 
         // make new chunks with proper offset
-        this.state.chunks[6] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset);
-        this.state.chunks[7] = new Chunk(this, this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset);
-        this.state.chunks[8] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset);
+        this.state.chunks[6] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset,plane_geos
+        [0]);
+        this.state.chunks[7] = new Chunk(this, this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset,plane_geos
+        [1]);
+        this.state.chunks[8] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset,plane_geos
+        [2]);
 
         this.add(this.state.chunks[6])
         this.add(this.state.chunks[7])
@@ -259,9 +263,12 @@ class ChunkManager extends Group {
         this.state.chunks[7] = this.state.chunks[6]
 
         // make new chunks with proper offset
-        this.state.chunks[0] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset);
-        this.state.chunks[3] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, this.state.currentZOffset);
-        this.state.chunks[6] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset);
+        this.state.chunks[0] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset,plane_geos
+        [0]);
+        this.state.chunks[3] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, this.state.currentZOffset,plane_geos
+        [1]);
+        this.state.chunks[6] = new Chunk(this, this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset,plane_geos
+        [2]);
 
         this.add(this.state.chunks[0])
         this.add(this.state.chunks[3])
@@ -305,9 +312,12 @@ class ChunkManager extends Group {
         this.state.chunks[7] = this.state.chunks[8]
 
         // make new chunks with proper offset
-        this.state.chunks[2] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset);
-        this.state.chunks[5] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, this.state.currentZOffset);
-        this.state.chunks[8] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset);
+        this.state.chunks[2] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, this.state.chunkWidth + this.state.currentZOffset, plane_geos
+        [0]);
+        this.state.chunks[5] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, this.state.currentZOffset, plane_geos
+        [1]);
+        this.state.chunks[8] = new Chunk(this, -this.state.chunkWidth + this.state.currentXOffset, 0, -this.state.chunkWidth + this.state.currentZOffset, plane_geos
+        [2]);
 
         this.add(this.state.chunks[2])
         this.add(this.state.chunks[5])

--- a/src/components/objects/TerrainPlane/TerrainPlane.js
+++ b/src/components/objects/TerrainPlane/TerrainPlane.js
@@ -5,7 +5,7 @@ const terrainSize = {width: 1000, height: 1000, vertsWidth: 100, vertsHeight: 10
 
 class TerrainPlane extends Group {
 
-    constructor(parent, xOffset, yOffset, zOffset) {
+    constructor(parent, xOffset, yOffset, zOffset, planeGeometry) {
         // console.log("CONSTRUCTOR TERRAIN PLANE")
         // Call parent Group() constructor
         super();
@@ -28,13 +28,12 @@ class TerrainPlane extends Group {
         this.state.zOffset = zOffset*parent.state.chunkVertWidth/parent.state.chunkWidth;
 
         // create the plane
-        this.geometry = new PlaneGeometry(parent.state.chunkWidth,parent.state.chunkWidth,
-                                    parent.state.chunkVertWidth - 1, parent.state.chunkVertWidth - 1)
+        this.geometry = planeGeometry;
         this.geometry.verticesNeedUpdate = true;
         this.geometry.colorsNeedUpdate = true;
 
         // get perline noise height map and update the geometry
-        this.heightMap = this.generateTexture(xOffset, zOffset)
+        this.heightMap = this.generateTexture(xOffset, zOffset);
         this.updateTerrainGeo();
 
         //required for flat shading

--- a/src/components/objects/TerrainPlane/TerrainPlane.js
+++ b/src/components/objects/TerrainPlane/TerrainPlane.js
@@ -172,9 +172,10 @@ class TerrainPlane extends Group {
     }
 
     disposeOf() {
-      this.geometry.dispose()
       this.material.dispose()
       this.remove(this.children[0])
+
+      return this.geometry;
     }
 
 }


### PR DESCRIPTION
Reuse plane geometry (don't have to generate each reload, load time has decreased from ~0.3s to essentially 0) - instead of disposing chunks, reuse them (return chunk in the disposeOf method instead of removing). Still glitching -- flashing the three blocks before (maybe has to do with reusing the old plane geometry? Might be threejs rendering shenanigans)