### PR TITLE
Move vr button to load after landing page

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,6 @@ renderer.xr.enabled = true;
 camera.position.y = 350 * Math.sin(Math.PI / 15);
 camera.position.z = -300;
 camera.lookAt(new Vector3(0, 50, 0));
-document.body.appendChild( VRButton.createButton( renderer ) );
 
     //TODO: Add styles to header
     let headID = document.getElementsByTagName('head')[0];
@@ -304,6 +303,7 @@ window.onload=function(){
     btn.addEventListener("click", function(){
         let loadingPage = document.getElementById('LoadingPage');
         document.body.removeChild(loadingPage);
+        document.body.appendChild( VRButton.createButton( renderer ) );
         document.body.style.overflow = 'hidden'; // Fix scrolling
         tour.start();
       })


### PR DESCRIPTION
Key Changes:
Moves the VR button to load after the landing page so it doesn't overlap with the "Get Started" button.

Screenshots:
<img width="1227" alt="Screen Shot 2020-07-17 at 9 02 45 AM" src="https://user-images.githubusercontent.com/8892509/87806819-491cac00-c80c-11ea-8a46-8cbd7074844c.png">
